### PR TITLE
Wait for the survey before we plow forward

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -19,14 +19,19 @@ define(function (require) {
     console.log(url);
     
     // TODO: Display a nice error if the survey wans't found.
-    $.getJSON(url, function(data) {
+    // TODO: Instead of deferred.pipe(), we should upgrade to jQuery >= 1.8 or
+    // use Q
+    return $.getJSON(url)
+    .pipe(function (data) {
       settings.surveyId = data.survey;
 
       // Actually get the survey metadata
       var surveyUrl = api.getSurveyURL();
-      $.getJSON(surveyUrl, function(survey){
+      return $.getJSON(surveyUrl)
+      .pipe(function (survey) {
         settings.survey = survey.survey;
         console.log(settings.survey);
+        return settings.survey;
       });
 
     });

--- a/js/app.js
+++ b/js/app.js
@@ -22,7 +22,7 @@ define(function (require) {
       console.log("Initialize NSB");
 
       // Get the survey, slug, etv.
-      api.getSurveyFromSlug();
+      var surveyPromise = api.getSurveyFromSlug();
 
       // Set the collector name, if we already know it.
       if ($.cookie('collectorName') !== null){
@@ -33,20 +33,30 @@ define(function (require) {
         console.log("Setting collector name");
 
         app.collectorName = $("#collector_name").val();      
-        $("#startpoint h2").html("Welcome, " + app.collectorName + "<br>Tap a parcel to begin");
-        $(".collector").val(app.collectorName);
+
+        $('#startpoint h2').html('Loading...');
+
+        $('.collector').val(app.collectorName);
 
         // Set a cookie with the collector's name
-        $.cookie("collectorName", app.collectorName, { path: '/' });
+        $.cookie('collectorName', app.collectorName, { path: '/' });
 
         // Hide the homepage, show the survey
         $('#home-container').slideToggle();
         $('#survey-container').slideToggle();
-        $("body").attr("id","survey");
+        $('body').attr('id', 'survey');
 
-        app.map = new MapView(app, 'map-div');
-        app.f = new FormView(app, '#form');
+        // Wait until we have the survey data
+        surveyPromise.done(function (survey) {
+          if (survey.type === 'point') {
+            $('#startpoint h2').html('Welcome, ' + app.collectorName + '<br>Pan and add a point to begin');
+          } else {
+            $('#startpoint h2').html('Welcome, ' + app.collectorName + '<br>Tap a parcel to begin');
+          }
 
+          app.map = new MapView(app, 'map-div');
+          app.f = new FormView(app, '#form');
+        });
       }); 
     },
 


### PR DESCRIPTION
Use the jQuery Deferred object, returned by the AJAX methods, so we can wait until data is available before we start using it.

Adjust the welcome text for point vs. parcel surveys.

This also fixes a bug when the survey data takes a really long time to arrive.

/cc @hampelm 
