### PR TITLE
Update to match API changes

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -45,7 +45,7 @@ define(function (require) {
   };
   
   api.getParcelDataURL = function(parcel_id) {
-    return settings.api.baseurl + '/surveys/' + settings.surveyId + '/parcels/' + parcel_id + '/responses';
+    return settings.api.baseurl + '/surveys/' + settings.surveyId + '/responses?objectId=' + parcel_id;
   };
   
   // Deprecated
@@ -130,7 +130,7 @@ define(function (require) {
     
     // Given the bounds, generate a URL to ge the responses from the API.
     var serializedBounds = southwest.lng + ',' + southwest.lat + ',' + northeast.lng + ',' + northeast.lat;
-    var url = api.getSurveyURL() + '/responses/in/' + serializedBounds;
+    var url = api.getSurveyURL() + '/responses?bbox=' + serializedBounds;
 
     // Give the callback the responses.
     $.getJSON(url, function(data){

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -597,7 +597,7 @@ define(function (require) {
 
         // Track the responses that we've added.
         _.each(results, function (response) {
-          var parcelId = response.geo_info.parcel_id;
+          var parcelId = response.parcel_id;
 
           if (zoom >= zoomLevels.checkmarkCutoff) {
             var point = new L.LatLng(response.geo_info.centroid[1], response.geo_info.centroid[0]);


### PR DESCRIPTION
Use the `bbox=1,2,3,4` query parameter format for restricting responses to a bounding box.

Look for parcel ID directly on the response object, since we don't consistently have that in the `geo_info` field.

/cc @hampelm 
