### PR TITLE
Switch to a street map after zoom 19

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -288,13 +288,23 @@ define(function (require) {
     this.init = function() {
       console.log('Initialize map');
       console.log(settings.survey);
-      map = new L.Map(mapContainerId, {minZoom:11, maxZoom:19});
+      map = new L.Map(mapContainerId, {minZoom:11, maxZoom:20});
 
       map.addLayer(parcelsLayerGroup);
       map.addLayer(doneMarkersLayer);
 
       // Add bing maps
-      var bing = new L.BingLayer(settings.bing_key, {maxZoom:19, type:'AerialWithLabels'});
+      var bingRoads = new L.BingLayer(settings.bing_key, {
+        minZoom: 20,
+        maxZoom: 20,
+        type: 'Road'
+      });
+      map.addLayer(bingRoads);
+
+      var bing = new L.BingLayer(settings.bing_key, {
+        maxZoom:19,
+        type:'AerialWithLabels'
+      });
       map.addLayer(bing);
 
       if (_.has(settings.survey, 'zones')) {


### PR DESCRIPTION
Bing has one more layer of street map after the satellite map ends at Z19. Mapbox streets and satellite both end at Z19, so we can't use our branded map here. Closes #92. 
