### PR TITLE
Don't show the street map at close zooms for now

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -288,7 +288,7 @@ define(function (require) {
     this.init = function() {
       console.log('Initialize map');
       console.log(settings.survey);
-      map = new L.Map(mapContainerId, {minZoom:11, maxZoom:20});
+      map = new L.Map(mapContainerId, {minZoom: 11, maxZoom: 19});
 
       map.addLayer(parcelsLayerGroup);
       map.addLayer(doneMarkersLayer);
@@ -303,12 +303,13 @@ define(function (require) {
 
       }else {
         // Add the Bing road map for very close zooms
-        var bingRoads = new L.BingLayer(settings.bing_key, {
-          minZoom: 20,
-          maxZoom: 20,
-          type: 'Road'
-        });
-        map.addLayer(bingRoads);
+        // Disabled for now since the layer is too light
+        // var bingRoads = new L.BingLayer(settings.bing_key, {
+        //   minZoom: 20,
+        //   maxZoom: 20,
+        //   type: 'Road'
+        // });
+        // map.addLayer(bingRoads);
 
         // Add the Bing satellite map
         var bing = new L.BingLayer(settings.bing_key, {


### PR DESCRIPTION
Turns out showing the street map at close zooms doesn't provide a good experience:
- Not enough features are shown in many areas, so it's unclear to users that they're looking at a street map
- Parcel layer outlines are too light on the Bing tiles, so we would need to restyle them 
- We can't use customizable Mapbox tiles, since they only go down toZ19
