### PR TITLE
Fix problem where questions with no parent are added to the wrong list

### DIFF
--- a/src/js/form.js
+++ b/src/js/form.js
@@ -423,11 +423,13 @@ define(function (require) {
       }
 
       // Record all questions by parent
-      if (app.questionsByParentId[parentID] === undefined) {
-        app.questionsByParentId[parentID] = [];
-      }
-      if (parentID !== undefined) {
-        app.questionsByParentId[parentID].push($question);
+      if(parentID !== undefined) {
+        var siblings = app.questionsByParentId[parentID];
+        if (siblings === undefined) {
+          siblings = [];
+          app.questionsByParentId[parentID] = siblings;
+        }
+        siblings.push($question);
       }
 
       // We may know what element we want to append to;


### PR DESCRIPTION
Previously, we'd add an `undefined` entry to the questions-by-parent list. 
