### PR TITLE
Support a custom survey prompt with survey.surveyOptions.prompt

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -50,7 +50,7 @@ define(function (require) {
       app.collectorName = $collectorName.val();
       $.cookie('collectorName', app.collectorName, { path: '/' });
 
-      if (app.collectorName == '') {
+      if (app.collectorName === '') {
         $collectorName.addClass('error');
         return;
       }
@@ -76,6 +76,10 @@ define(function (require) {
         $('#startpoint h2').html('Welcome, ' + app.collectorName + '<br>Enter an address to begin');
       } else {
         $('#startpoint h2').html('Welcome, ' + app.collectorName + '<br>Tap a parcel to begin');
+      }
+
+      if (settings.survey.surveyOptions && settings.survey.surveyOptions.prompt) {
+        $('#startpoint h2').html('Welcome, ' + app.collectorName + '<br>' + settings.survey.surveyOptions.prompt);
       }
 
       if (settings.survey.type === 'address-point') {


### PR DESCRIPTION
If `survey.surveyOptions.prompt` is set, it will override all other prompts for the first entry. 

For future entries, the "Select another location to continue" prompt will continue to be used for simplicity. 

![screen shot 2014-12-20 at 4 08 24 pm](https://cloud.githubusercontent.com/assets/86435/5516298/c1b5b8ea-8862-11e4-84c0-3cb61deb7a1f.png)
