### PR TITLE
Fix the spinbox plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,7 +70,14 @@ module.exports = function(grunt) {
         files: [ {
           expand: true,     // Enable dynamic expansion.
           cwd: 'src/',      // Src matches are relative to this path.
-          src: ['css/jquery.mobile.css', 'css/localdata.css', 'css/mobile.css', 'css/jquery.mobile.structure-1.4.0.min.css'], // Actual pattern(s) to match.
+          // Actual pattern(s) to match.
+          src: [
+            'css/jquery.mobile.css',
+            'css/localdata.css',
+            'css/mobile.css',
+            'css/jquery.mobile.structure-1.4.0.min.css',
+            'js/lib/leaflet/leaflet.css'
+          ],
           dest: '<%= dirs.staging %>'   // Destination path prefix.
         } ]
       }

--- a/src/js/lib/jquery.mobile.spinbox.js
+++ b/src/js/lib/jquery.mobile.spinbox.js
@@ -5,7 +5,7 @@
  * https://github.com/jtsage/jquery-mobile-spinbox
  */
 
-(function($) {
+define(['jquery'], function ($) {
     $.widget( "mobile.spinbox", {
         options: {
             // All widget options
@@ -241,4 +241,4 @@
             this.options.disabled = false;
         }
     });
-})( jQuery );
+});

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -42,7 +42,7 @@ require(['jquery', 'app', 'lib/jquery.mobile', 'lib/jquery.cookie',
                   logLevel, lawnchair, adapterIDB, adapterWebSQL) {
   'use strict';
 
-  logLevel('verbose'); // silent or verbose
+  logLevel('silent'); // Default is verbose.
   // $(document).trigger('mobileinit');
   $(document).ready(function() {
     app.init();


### PR DESCRIPTION
Convert the spinbox plugin to an AMD module. It's a simple enough change that we can maintain it across upstream changes.

Add an apparently missing CSS file to Gruntfile.js. Likely this was deployed at some point, so the production deployment might have it by coincidence.

Switch logging back to silent, to avoid memory leaks in production. We can always turn it back on from the console if we need logging for a deployed app.

/cc @hampelm 
