### PR TITLE
Capture enter-presses from the collector name input

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -110,7 +110,10 @@ define(function (require) {
           $collectorName.val($.cookie('collectorName'));
         }
 
+        // Capture clicks on the "Get started" button as well as Enter-presses
+        // from the input box.
         $collectorNameSubmit.click(app.getStarted);
+        $('#welcome-form').submit(app.getStarted);
       });
     },
 


### PR DESCRIPTION
Don't let the input trigger a navigation. Have enter presses behave the same as clicks on the get-started button.