### PR TITLE
Support rendered parcel tiles when zoomed way out

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -383,6 +383,23 @@ define(function (require) {
       }
     });
   };
+  
+  api.getTileJSON = function getTileJSON() {
+    return $.ajax({
+      url: '/tiles/features/tile.json',
+      type: 'GET',
+      dataType: 'json',
+      cache: false,
+      data: {
+        layerDefinition: JSON.stringify({
+          query: {
+            type: 'parcels'
+          },
+          styles: settings.renderedStyles
+        })
+      }
+    });
+  };
 
 
   // Deal with the formatting of the geodata API.

--- a/src/js/lib/leaflet.tilejson.js
+++ b/src/js/lib/leaflet.tilejson.js
@@ -1,0 +1,147 @@
+if (typeof L == "undefined"
+    || typeof L.version == "undefined"
+    || L.version < '0.4') {
+    throw "Leaflet not loaded or version is < 0.4";
+}
+
+L.TileJSON = (function() {
+    var handlers = {
+        tilejson: function(context, tilejson) {
+            var v = semver.parse(tilejson);
+            if (!v || v[1] != 2) {
+                throw new Error('This parser supports version 2 '
+                                    + 'of TileJSON. (Provided version: "'
+                                    + tilejson.tilejson + '"');
+            }
+
+            context.validation.version = true;
+        },
+        minzoom: function(context, minZoom) {
+            context.tileLayer.minZoom = minZoom;
+        },
+        maxzoom: function(context, maxZoom) {
+            context.tileLayer.maxZoom = maxZoom;
+        },
+        center: function(context, center) {
+            context.map.center = new L.LatLng(center[1], center[0]);
+            context.map.zoom = center[2];
+        },
+        attribution: function(context, attribution) {
+            context.map.attributionControl = true;
+            context.tileLayer.attribution = attribution;
+        },
+        projection: function(context, projection) {
+            context.crs.projection = projection;
+        },
+        transform: function(context, t) {
+            context.crs.transformation =
+                new L.Transformation(t[0], t[1], t[2], t[3]);
+        },
+        crs: function(context, crs) {
+            context.crs.code = crs;
+        },
+        scales: function(context, s) {
+            context.crs.scale = function(zoom) {
+                return s[zoom];
+            };
+        },
+        scheme: function(context, scheme) {
+            context.tileLayer.scheme = scheme;
+        },
+        tilesize: function(context, tileSize) {
+            context.tileLayer.tileSize = tileSize;
+        },
+        tiles: function(context, tileUrls) {
+            context.tileUrls = tileUrls;
+        }
+    };
+
+    var semver = (function() {
+        var pattern = "\\s*[v=]*\\s*([0-9]+)"    // major
+            + "\\.([0-9]+)"                  // minor
+            + "\\.([0-9]+)"                  // patch
+            + "(-[0-9]+-?)?"                 // build
+            + "([a-zA-Z-][a-zA-Z0-9-\.:]*)?"; // tag
+        var semverRegEx = new RegExp("^\\s*"+pattern+"\\s*$");
+
+        return {
+            parse: function(v) {
+                return v.match(semverRegEx);
+            }
+        };
+    })();
+
+    function defined(o){
+        return (typeof o !== "undefined" && o !== null);
+    }
+
+    function parseTileJSON(tileJSON, options) {
+        var context = {
+            tileLayer: L.Util.extend({
+                minZoom: 0,
+                maxZoom: 22
+            }, options.tileLayerConfig || {}),
+
+            map: L.Util.extend({}, options.mapConfig || {}),
+
+            crs: {},
+
+            validation: {
+                // version: false
+            }
+        };
+
+        for (var key in handlers) {
+            if (defined(tileJSON[key])) {
+                handlers[key](context, tileJSON[key], tileJSON);
+            }
+        }
+
+        for (var validationKey in context.validation) {            
+            if (!context.validation[validationKey]) {
+                throw new Error('Missing property "'
+                    + validationKey + '".');
+            }
+        }
+
+        if (defined(context.crs.projection)) {
+            context.map.crs =
+                new L.CRS.proj4js(
+                    context.crs.code,
+                    context.crs.projection,
+                    context.crs.transformation);
+            if (defined(context.crs.scale)) {
+                context.map.crs.scale = context.crs.scale;
+            }
+            // TODO: Setting continuousWorld to true might
+            // not be correct for all projections.
+            context.map.continuousWorld = true;
+            context.tileLayer.continuousWorld = true;
+        }
+
+        return context;
+    }
+
+    function createTileLayer(context) {
+        var tileUrl = context.tileUrls[0].replace(/\$({[sxyz]})/g, '$1');
+        return new L.TileLayer(tileUrl, context.tileLayer);
+    };
+
+    return {
+        createMapConfig: function(tileJSON, cfg) {
+            return parseTileJSON(tileJSON, {mapConfig: cfg}).map;
+        },
+        createTileLayerConfig: function(tileJSON, cfg) {
+            return parseTileJSON(tileJSON, {tileLayerConfig: cfg}).tileLayer;
+        },
+        createTileLayer: function(tileJSON, options) {
+            var context = parseTileJSON(tileJSON, options || {});
+            return createTileLayer(context);
+        },
+        createMap: function(id, tileJSON, options) {
+            var context = parseTileJSON(tileJSON, options || {});
+            context.map.layers = [createTileLayer(context)];
+            return new L.Map(id, context.map);
+        }
+    };
+}());

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -30,6 +30,10 @@ require.config({
     'lib/leaflet': {
       exports: 'L'
     },
+    'lib/leaflet.tilejson': {
+      deps: ['lib/leaflet'],
+      exports: 'L'
+    },
     'lib/tilelayer.bing.pull': ['lib/leaflet']
   }
 });

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -155,6 +155,8 @@ define(function (require) {
       }
     }
   };
+  
+  settings.renderedStyles = '#localdata { line-color: white; line-width: 1; line-opacity: 0.6; polygon-fill: white; polygon-opacity: 0.3; }';
 
   return settings;
 });


### PR DESCRIPTION
Condition on a survey's `farParcels` flag

Useful for sparse, spread-out surveys, where the user needs to zoom out quite a bit to identify an area with coverage.

![image](https://cloud.githubusercontent.com/assets/1307783/8483102/10e2b692-20a3-11e5-984b-e2363d243eec.png)

The styles are currently probably just OK for parcels. If this becomes useful for other survey types, we can improve the rendering for things like intersections, sidewalks, etc.

/cc @hampelm 