### PR TITLE
Ensure unique, non-empty names when adding to FormData objects

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -149,7 +149,7 @@ define(function (require) {
     _.each(response.files, function (item) {
       var f = $.canvasResize('dataURLtoBlob', item.data);
       f.name = item.name;
-      fd.append(item.fieldName, f, f.name);
+      fd.append(_.uniqueId('photo_'), f, f.name);
     });
 
     // Remove the file data from the response object, since we will include


### PR DESCRIPTION
Empty names seemed to cause issues on some mobile browsers, preventing successful file upload. Duplicate names caused an issue (potentially hitting a bug in the multipart upload library) on the server. The filename is stored separately, and we don't use the FormData name, so a unique ID should be fine.

/cc @hampelm 
